### PR TITLE
Minor updates for PowerShell 5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ bld/
 # Roslyn cache directories
 *.ide/
 
+# Visual Studio cache/options directory
+.vs/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/Enable-OneNote.ps1
+++ b/Enable-OneNote.ps1
@@ -26,7 +26,7 @@ if (!$silent -and $(test-command "Get-FileVersionInfo"))
 }
 
 
-Add-PSSnapin Microsoft.Office.OneNote
+Import-Module "$($OneNoteHome)\Microsoft.Office.OneNote.PowerShell.dll"
 Update-FormatData "$($OneNoteHome)\OneNote.ps1xml"
 $global:OneNoteHome = $OneNoteHome
 

--- a/Enable-OneNote.ps1
+++ b/Enable-OneNote.ps1
@@ -5,6 +5,8 @@
 
 param([switch]$silent)
 
+Set-StrictMode -Off
+
 if ($args[0] -eq "-?")
 {
 	 Get-Content $(Get-Command Enable-OneNote.help.txt).Definition

--- a/Scripts/ConvertTo-Object.ps1
+++ b/Scripts/ConvertTo-Object.ps1
@@ -5,6 +5,8 @@
 
 begin
 {
+	 Set-StrictMode -Off
+
 	 if ($args[0] -eq '-?')
 	 {
 		  get-content $(get-command ConvertTo-Object.help.txt).Definition

--- a/Scripts/Create-OneNoteDocumentation.ps1
+++ b/Scripts/Create-OneNoteDocumentation.ps1
@@ -4,6 +4,8 @@
 ##  is then exported to a ONEPKG file.
 ##
 
+Set-StrictMode -Off
+
 if ($args[0] -eq '-?')
 {
 	 Get-Content $(Get-Command Create-OneNoteDocumentation.help.txt).Definition

--- a/Scripts/Export-PsOn.ps1
+++ b/Scripts/Export-PsOn.ps1
@@ -10,6 +10,8 @@ param( $path, $encoding = 'ASCII', [switch]$passThru, [switch]$stdout )
 
 begin
 {
+	 Set-StrictMode -Off
+
 	 if ($args[0] -eq "-?")
 	 {
 		  Get-Content $(Get-Command Export-PsOn.help.txt).Definition

--- a/Scripts/Get-OneNoteDigest.ps1
+++ b/Scripts/Get-OneNoteDigest.ps1
@@ -195,7 +195,7 @@ Convert-Xml -Path "$outputDirectory\manifest.xml" -XsltPath $Stylesheet > `
 ##  Send the mail message.
 ##
 
-$body = gc "$outputDirectory\manifest.htm" | join-string -newline
+$body = gc "$outputDirectory\manifest.htm" -Raw
 if (!$whatIf)
 {
 	 Send-SmtpMail -to $MailTo -from bdewey@exchange.microsoft.com -subject "$notebookName Digest" `

--- a/Scripts/Get-OneNoteDigest.ps1
+++ b/Scripts/Get-OneNoteDigest.ps1
@@ -14,6 +14,8 @@ param( $Notebook,
     [switch]$noClean,
     [switch]$Verbose )
 
+Set-StrictMode -Off
+
 if ($args[0] -eq '-?')
 {
 	 Get-Content $(Get-Command Get-OneNoteDigest.help.txt).Definition

--- a/Scripts/Get-OneNoteText.ps1
+++ b/Scripts/Get-OneNoteText.ps1
@@ -4,6 +4,8 @@
 
 param( $OneNotePath, $Stylesheet )
 
+Set-StrictMode -Off
+
 if ($args[0] -eq "-?")
 {
 	 Get-Content $(Get-Command Get-OneNoteText.help.txt).Definition

--- a/Scripts/Get-ProviderTests.ps1
+++ b/Scripts/Get-ProviderTests.ps1
@@ -91,7 +91,7 @@ If you pipe a FileInfo object to add-content, then the file will be embedded on 
      ScriptBlock={
 
 
-            dir $PSHome\Documents\EN-US\GettingStarted.rtf | add-content "OneNote:\TempNotebook\Section\Page 2"
+            dir "$env:SystemRoot\System32\oobe\en-US\privacy.rtf" | add-content "OneNote:\TempNotebook\Section\Page 2"
             type "OneNote:\TempNotebook\Section\Page 2"
         
 

--- a/Scripts/Import-FilesToOneNote.ps1
+++ b/Scripts/Import-FilesToOneNote.ps1
@@ -9,6 +9,8 @@ param(
      $SubstituteContentExtension
      )
 
+Set-StrictMode -Off
+
 if ($args[0] -eq "-?")
 {
 	 Get-Content $(Get-Command Import-FilesToOneNote.help.txt).Definition

--- a/Scripts/Start-Tests.ps1
+++ b/Scripts/Start-Tests.ps1
@@ -126,7 +126,7 @@ process
 			   break
 		  }
 	 }
-	 $resultString = $results | out-string | join-string -newline
+	 $resultString = $results | out-string
 	 $resultString = $resultString.Trim()
 	 write-host "`n", $resultString, "`n" -sep $null
 	 if ($_.ExpectedString)

--- a/Scripts/Start-Tests.ps1
+++ b/Scripts/Start-Tests.ps1
@@ -13,6 +13,7 @@ param( $Filter,
 
 begin
 {
+	 Set-StrictMode -Off
 
 	 if ($args[0] -eq "-?")
 	 {


### PR DESCRIPTION
"Snapins" aren't really a thing anymore; Import-Module is what we need to do to load the module.

StrictMode *is* a thing now. Some people use it, some don't, but these scripts were written assuming it was off, so let's make it explicit.

There was no join-string function... don't know if that was something that existed in older PS versions or what.